### PR TITLE
Open individual events from event lists

### DIFF
--- a/src/main/java/com/google/sps/servlets/EventServlet.java
+++ b/src/main/java/com/google/sps/servlets/EventServlet.java
@@ -17,6 +17,9 @@ package com.google.sps.servlets;
 import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
+import com.google.appengine.api.datastore.Key;
+import com.google.appengine.api.datastore.KeyFactory;
+import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.users.UserService;
 import com.google.appengine.api.users.UserServiceFactory;
 import com.google.gson.Gson;
@@ -53,12 +56,27 @@ public class EventServlet extends HttpServlet {
       DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
       datastore.put(eventEntity);
 
+      allocateEventKey(eventEntity);
+
     } else {
       throw new IOException("Cannot create an event while not logged in");
     }
 
     // Redirect back to the my-events HTML page.
     response.sendRedirect("/my-events.html");
+  }
+
+  private void allocateEventKey(Entity event) {
+    Key eventKey = event.getKey();
+    String keyString = KeyFactory.keyToString(eventKey);
+
+    Query query = new Query("Event", eventKey);
+
+    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    Entity eventCreated = datastore.prepare(query).asSingleEntity();
+
+    eventCreated.setProperty("eventKey", keyString);
+    datastore.put(eventCreated);
   }
 
   /** @return the Event entity */

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -303,7 +303,7 @@ async function getEvents(events, index, option) {
     const eventItemElement = document.createElement('a');
     eventItemElement.className = 'event-item';
     eventItemElement.setAttribute('onclick', 'openLink("' +
-        event.key + '")');
+        event.eventKey + '")');
     eventListElement.appendChild(eventItemElement);
 
     const eventImageElement = document.createElement('div');

--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -163,6 +163,7 @@ public final class EventServletTest {
     goalEntity.setIndexedProperty("tags", Arrays.asList(tags));
     goalEntity.setProperty("creator", creatorEmail);
     goalEntity.setProperty("attendeeCount", 0L);
+    goalEntity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgBDA");
 
     // Retrieve the Entity posted to Datastore.
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();


### PR DESCRIPTION
With this PR, events now open when clicked on. I added an eventKey property to the event entity. In order to do this, I had to put the event in datastore, get the key, pull the event from datastore, and then update the event entity. I ordered it this way because automatically generated keys/id can only be accessed once stored in datastore.