### PR TITLE
Load LGBTQ+ features and update individual page

### DIFF
--- a/src/main/java/com/google/sps/servlets/LoadEventServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoadEventServlet.java
@@ -106,6 +106,7 @@ public class LoadEventServlet extends HttpServlet {
     request.setAttribute("attendees", attendeeCount);
     request.setAttribute("saved", alreadySaved);
 
+
     return request;
   }
 

--- a/src/main/java/com/google/sps/servlets/LoadEventServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoadEventServlet.java
@@ -93,6 +93,7 @@ public class LoadEventServlet extends HttpServlet {
     String address = event.getProperty("address").toString();
     String tags = Utils.convertToJson(event.getProperty("tags"));
     String attendeeCount = event.getProperty("attendeeCount").toString();
+    String key = event.getProperty("eventKey").toString();
     long eventId = event.getKey().getId();
 
     request.setAttribute("name", name);
@@ -105,7 +106,7 @@ public class LoadEventServlet extends HttpServlet {
     request.setAttribute("id", eventId);
     request.setAttribute("attendees", attendeeCount);
     request.setAttribute("saved", alreadySaved);
-
+    request.setAttribute("key", key);
 
     return request;
   }

--- a/src/main/webapp/WEB-INF/jsp/display-event.jsp
+++ b/src/main/webapp/WEB-INF/jsp/display-event.jsp
@@ -57,6 +57,7 @@
           <div class="share-wrapper">
             <h3>Share</h3>
             <div class="share-container">
+              <input type="hidden" id="event-key" value='${key}'>
               <a id="twitter-link" target="_blank">
                   <img src="images/twitter.svg" alt="Twitter"/>
               </a>

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -321,7 +321,9 @@ async function getEvents(events, index, option) {
     eventListElement.appendChild(eventItemElement);
 
     const eventImageElement = document.createElement('div');
-    eventImageElement.className = 'event-image ' + event.tags[0];
+    let primaryTag = event.tags[0];
+    if (primaryTag == 'LGBTQ+') primaryTag = 'LGBTQ';
+    eventImageElement.className = 'event-image ' + primaryTag;
 
     const eventItemInfoElement = document.createElement('div');
     eventItemInfoElement.className = 'event-item-info';
@@ -422,7 +424,7 @@ async function getEvents(events, index, option) {
       attendeeCountContainerElement.className = 'attendee-count-container';
 
       const attendeeCountElement = document.createElement('span');
-      attendeeCountElement.className = 'attendee-count ' + event.tags[0] +
+      attendeeCountElement.className = 'attendee-count ' + primaryTag +
           '-text';
       attendeeCountElement.innerText = event.attendeeCount;
       attendeeCountContainerElement.appendChild(attendeeCountElement);
@@ -444,6 +446,7 @@ async function getEvents(events, index, option) {
       tagsContainerElement.appendChild(tagElement);
     });
   });
+  generateRainbowTags();
 
   // generates this structure:
   //

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -956,6 +956,7 @@ function displayIndividualEvent(id = 0, alreadySaved = -1) {
   loadDefaultImage(mainColor);
   loadAttendingColor(mainColor);
   loadOptionalFields();
+  loadLinks();
   setupSave(id, alreadySaved);
 }
 
@@ -1012,6 +1013,20 @@ function loadOptionalFields() {
 
     timeContainer.appendChild(end);
   }
+}
+
+function loadLinks() {
+  const eventKey = document.getElementById('event-key').value;
+  const twitter = document.getElementById('twitter-link');
+  const facebook = document.getElementById('fb-link');
+  const mail = document.getElementById('mail-link');
+  const url = 'http://unitebystep.appspot.com/load-event?Event=' + eventKey;
+  const br = '%0D%0A%0D%0A';
+
+  twitter.href = 'https://twitter.com/share?url=' + url;
+  facebook.href = 'http://www.facebook.com/sharer.php?u=' + url;
+  mail.href =
+   'mailto:?subject=Unite by STEP Event&body=Check out this event!' + br + url;
 }
 
 /**

--- a/src/main/webapp/script.js
+++ b/src/main/webapp/script.js
@@ -1015,6 +1015,9 @@ function loadOptionalFields() {
   }
 }
 
+/**
+ * Generates share links for Facebook, Twitter, and mail.
+ */
 function loadLinks() {
   const eventKey = document.getElementById('event-key').value;
   const twitter = document.getElementById('twitter-link');


### PR DESCRIPTION
LGBTQ+ default images and colors now load on event lists. Also, attendees and links now function correctly on individual pages.