### PR TITLE
Saving interactions

### DIFF
--- a/src/main/java/com/google/sps/Interactions.java
+++ b/src/main/java/com/google/sps/Interactions.java
@@ -142,9 +142,18 @@ public class Interactions {
       for (Entity entity : pq.asIterable()) {
         toDelete.add(entity.getKey());
       }
+      LOGGER.warning(
+          "multiple entries found for "
+              + userId
+              + " and "
+              + eventId
+              + ". Deleting "
+              + toDelete.size()
+              + " entries.");
       datastore.delete(toDelete);
     } catch (NullPointerException e) {
       // do nothing, pass to finally block
+      LOGGER.info("No entries yet for " + userId + " and " + eventId + ". Creating one now.");
     } finally {
       if (interactionEntity == null) {
         interactionEntity = new Entity("Interaction");

--- a/src/main/java/com/google/sps/Interactions.java
+++ b/src/main/java/com/google/sps/Interactions.java
@@ -29,9 +29,9 @@ public class Interactions {
   private static final Logger LOGGER = Logger.getLogger(Interactions.class.getName());
 
   // contributions to user's interest metrics for each action
-  public static final int VIEW_SCORE = 1;
-  public static final int SAVE_SCORE = 3;
-  public static final int CREATE_SCORE = 5;
+  public static final int VIEW_SCORE = 4;
+  public static final int SAVE_SCORE = 8;
+  public static final int CREATE_SCORE = 10;
 
   // interest categories, matches question order on survey pages
   public static final String[] metrics = {"environment", "blm", "volunteer", "education", "LGBTQ+"};

--- a/src/main/java/com/google/sps/Interactions.java
+++ b/src/main/java/com/google/sps/Interactions.java
@@ -41,7 +41,7 @@ public class Interactions {
   public static final int SAVE_SCORE = 8;
   public static final int CREATE_SCORE = 10;
 
-  // affects on scores of "undoing" actions
+  // effects on scores when "undoing" actions
   public static final int UNSAVE_DELTA = -2;
   public static final int DELETE_DELTA = -3;
 

--- a/src/main/java/com/google/sps/Recommend.java
+++ b/src/main/java/com/google/sps/Recommend.java
@@ -40,7 +40,7 @@ public class Recommend {
     // get user prefs
     Map<String, Map<String, Integer>> userPrefs = new HashMap<>();
     for (Entity e : queriedUsers) {
-    //   userPrefs.put(e.getKey().getName(), Interactions.buildVectorForEvent(e));
+      //   userPrefs.put(e.getKey().getName(), Interactions.buildVectorForEvent(e));
     }
 
     Iterable<Entity> currentRecs = datastore.prepare(new Query("UserRecs")).asIterable();

--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -132,7 +132,7 @@ public class Utils {
   }
 
   /**
-   * Creates and returns a new Entity for a given userId
+   * Creates and returns a new Entity for a given userId.
    *
    * @param userId to identify this user in datastore
    * @param location user's location
@@ -150,7 +150,7 @@ public class Utils {
   }
 
   /**
-   * Creates and returns a new Entity for a given userId, no location given
+   * Creates and returns a new Entity for a given userId, no location given.
    *
    * @param userId to identify this user in datastore
    * @param addToDatastore if true, will add this entity to datastore as well

--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -14,6 +14,8 @@
 
 package com.google.sps;
 
+import com.google.appengine.api.datastore.DatastoreService;
+import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.gson.Gson;
 import com.google.maps.DistanceMatrixApi;
@@ -27,7 +29,6 @@ import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import java.io.IOException;
 import java.util.Comparator;
-import java.util.Map;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 
@@ -130,6 +131,34 @@ public class Utils {
     return distance;
   }
 
+  /**
+   * Creates and returns a new Entity for a given userId
+   *
+   * @param userId to identify this user in datastore
+   * @param location user's location
+   * @param addToDatastore if true, will add this entity to datastore as well
+   */
+  public static Entity makeUserEntity(String userId, String location, boolean addToDatastore) {
+    Entity userEntity = new Entity("User", userId);
+    userEntity.setProperty("firebaseID", userId);
+    userEntity.setProperty("location", location);
+    if (addToDatastore) {
+      DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+      datastore.put(userEntity);
+    }
+    return userEntity;
+  }
+
+  /**
+   * Creates and returns a new Entity for a given userId, no location given
+   *
+   * @param userId to identify this user in datastore
+   * @param addToDatastore if true, will add this entity to datastore as well
+   */
+  public static Entity makeUserEntity(String userId, boolean addToDatastore) {
+    return makeUserEntity(userId, "", addToDatastore);
+  }
+
   // comparators to apply sort to results
   public static final Comparator<Entity> ORDER_BY_NAME =
       new Comparator<Entity>() {
@@ -144,21 +173,21 @@ public class Utils {
         }
       };
 
-  /** creates a comparator based on entity dot product with a given vector. */
-  public static Comparator<Entity> getComparatorByInterestMatch(Map<String, Integer> metrics) {
-    Comparator<Entity> result =
-        new Comparator<Entity>() {
-          @Override
-          public int compare(Entity a, Entity b) {
-            if (!a.getKind().equals("Event") || !b.getKind().equals("Event")) {
-              throw new IllegalArgumentException("must be event items");
-            }
-            Map<String, Integer> v1 = Interactions.buildVectorForEvent(a);
-            Map<String, Integer> v2 = Interactions.buildVectorForEvent(b);
-            return Integer.compare(
-                Interactions.dotProduct(v1, metrics), Interactions.dotProduct(v2, metrics));
-          }
-        };
-    return result;
-  }
+  //   /** creates a comparator based on entity dot product with a given vector. (not used) */
+  //   public static Comparator<Entity> getComparatorByInterestMatch(Map<String, Integer> metrics) {
+  //     Comparator<Entity> result =
+  //         new Comparator<Entity>() {
+  //           @Override
+  //           public int compare(Entity a, Entity b) {
+  //             if (!a.getKind().equals("Event") || !b.getKind().equals("Event")) {
+  //               throw new IllegalArgumentException("must be event items");
+  //             }
+  //             Map<String, Integer> v1 = Interactions.buildVectorForEvent(a);
+  //             Map<String, Integer> v2 = Interactions.buildVectorForEvent(b);
+  //             return Integer.compare(
+  //                 Interactions.dotProduct(v1, metrics), Interactions.dotProduct(v2, metrics));
+  //           }
+  //         };
+  //     return result;
+  //   }
 }

--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -29,6 +29,7 @@ import com.google.maps.model.GeocodingResult;
 import com.google.maps.model.LatLng;
 import java.io.IOException;
 import java.util.Comparator;
+import java.util.Map;
 import java.util.logging.Logger;
 import javax.servlet.http.HttpServletRequest;
 
@@ -158,7 +159,7 @@ public class Utils {
   public static Entity makeUserEntity(String userId, boolean addToDatastore) {
     return makeUserEntity(userId, "", addToDatastore);
   }
-  
+
   /** Orders a map from greatest to least based off its values. */
   public static final Comparator<Map.Entry<String, Integer>> ORDER_MAP_GREATEST_TO_LEAST =
       new Comparator<Map.Entry<String, Integer>>() {

--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -172,22 +172,4 @@ public class Utils {
               .compareTo(b.getProperty("eventName").toString());
         }
       };
-
-  //   /** creates a comparator based on entity dot product with a given vector. (not used) */
-  //   public static Comparator<Entity> getComparatorByInterestMatch(Map<String, Integer> metrics) {
-  //     Comparator<Entity> result =
-  //         new Comparator<Entity>() {
-  //           @Override
-  //           public int compare(Entity a, Entity b) {
-  //             if (!a.getKind().equals("Event") || !b.getKind().equals("Event")) {
-  //               throw new IllegalArgumentException("must be event items");
-  //             }
-  //             Map<String, Integer> v1 = Interactions.buildVectorForEvent(a);
-  //             Map<String, Integer> v2 = Interactions.buildVectorForEvent(b);
-  //             return Integer.compare(
-  //                 Interactions.dotProduct(v1, metrics), Interactions.dotProduct(v2, metrics));
-  //           }
-  //         };
-  //     return result;
-  //   }
 }

--- a/src/main/java/com/google/sps/servlets/EventServlet.java
+++ b/src/main/java/com/google/sps/servlets/EventServlet.java
@@ -25,6 +25,7 @@ import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.sps.Firebase;
 import com.google.sps.Interactions;
+import com.google.sps.Utils;
 import java.io.IOException;
 import java.text.DateFormat;
 import java.text.ParseException;
@@ -71,9 +72,7 @@ public class EventServlet extends HttpServlet {
     try {
       userEntity = datastore.get(userKey);
     } catch (EntityNotFoundException exception) {
-      // datastore entry has not been created yet for this user, create it now
-      userEntity = new Entity(userKey);
-      userEntity.setProperty("firebaseID", userID);
+      userEntity = Utils.makeUserEntity(userID, false);
     }
     int delta = Interactions.recordInteraction(userID, keyId, Interactions.CREATE_SCORE, false);
     Interactions.updatePrefs(userEntity, tags, delta);

--- a/src/main/java/com/google/sps/servlets/EventServlet.java
+++ b/src/main/java/com/google/sps/servlets/EventServlet.java
@@ -75,7 +75,7 @@ public class EventServlet extends HttpServlet {
       userEntity = new Entity(userKey);
       userEntity.setProperty("firebaseID", userID);
     }
-    int delta = Interactions.recordInteraction(userID, keyId, Interactions.CREATE_SCORE);
+    int delta = Interactions.recordInteraction(userID, keyId, Interactions.CREATE_SCORE, false);
     Interactions.updatePrefs(userEntity, tags, delta);
     datastore.put(userEntity);
 

--- a/src/main/java/com/google/sps/servlets/EventServlet.java
+++ b/src/main/java/com/google/sps/servlets/EventServlet.java
@@ -73,6 +73,7 @@ public class EventServlet extends HttpServlet {
       userEntity = datastore.get(userKey);
     } catch (EntityNotFoundException exception) {
       userEntity = Utils.makeUserEntity(userID, false);
+      LOGGER.info("No entity found for " + userID + ", creating one now.");
     }
     int delta = Interactions.recordInteraction(userID, keyId, Interactions.CREATE_SCORE, false);
     Interactions.updatePrefs(userEntity, tags, delta);

--- a/src/main/java/com/google/sps/servlets/LoadEventServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoadEventServlet.java
@@ -69,7 +69,7 @@ public class LoadEventServlet extends HttpServlet {
             }
             int delta =
                 Interactions.recordInteraction(
-                    userID, keyRequested.getId(), Interactions.CREATE_SCORE);
+                    userID, keyRequested.getId(), Interactions.VIEW_SCORE, false);
             Interactions.updatePrefs(userEntity, tags, delta);
             datastore.put(userEntity);
           }

--- a/src/main/java/com/google/sps/servlets/LoadEventServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoadEventServlet.java
@@ -61,11 +61,8 @@ public class LoadEventServlet extends HttpServlet {
             try {
               userEntity = datastore.get(userKey);
               alreadySaved = UserServlet.alreadySaved(eventRequested.getKey().getId(), userEntity);
-
             } catch (EntityNotFoundException exception) {
-              // datastore entry has not been created yet for this user, create it now
-              userEntity = new Entity(userKey);
-              userEntity.setProperty("firebaseID", userID);
+              userEntity = Utils.makeUserEntity(userID, false);
             }
             int delta =
                 Interactions.recordInteraction(

--- a/src/main/java/com/google/sps/servlets/LoadEventServlet.java
+++ b/src/main/java/com/google/sps/servlets/LoadEventServlet.java
@@ -63,6 +63,7 @@ public class LoadEventServlet extends HttpServlet {
               alreadySaved = UserServlet.alreadySaved(eventRequested.getKey().getId(), userEntity);
             } catch (EntityNotFoundException exception) {
               userEntity = Utils.makeUserEntity(userID, false);
+              LOGGER.info("No entity found for " + userID + ", creating one now.");
             }
             int delta =
                 Interactions.recordInteraction(

--- a/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -50,6 +50,7 @@ public class LocationServlet extends HttpServlet {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException exception) {
         userEntity = Utils.makeUserEntity(userID, "", true);
+        LOGGER.info("No entity found for " + userID + ", creating one now.");
       }
       location = userEntity.getProperty("location").toString();
     }

--- a/src/main/java/com/google/sps/servlets/LocationServlet.java
+++ b/src/main/java/com/google/sps/servlets/LocationServlet.java
@@ -49,11 +49,7 @@ public class LocationServlet extends HttpServlet {
       try {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException exception) {
-        // datastore entry has not been created yet for this user, create it now
-        userEntity = new Entity(userKey);
-        userEntity.setProperty("firebaseID", userID);
-        userEntity.setProperty("location", "");
-        datastore.put(userEntity);
+        userEntity = Utils.makeUserEntity(userID, "", true);
       }
       location = userEntity.getProperty("location").toString();
     }

--- a/src/main/java/com/google/sps/servlets/SurveyServlet.java
+++ b/src/main/java/com/google/sps/servlets/SurveyServlet.java
@@ -54,6 +54,7 @@ public class SurveyServlet extends HttpServlet {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException e) {
         userEntity = Utils.makeUserEntity(userID, true);
+        LOGGER.info("No entity found for " + userID + ", creating one now.");
       }
 
       // save score of each survey metric as an entity property

--- a/src/main/java/com/google/sps/servlets/SurveyServlet.java
+++ b/src/main/java/com/google/sps/servlets/SurveyServlet.java
@@ -23,6 +23,7 @@ import com.google.appengine.api.datastore.KeyFactory;
 import com.google.gson.Gson;
 import com.google.sps.Firebase;
 import com.google.sps.Interactions;
+import com.google.sps.Utils;
 import java.io.IOException;
 import java.util.logging.Logger;
 import javax.servlet.annotation.WebServlet;
@@ -52,9 +53,7 @@ public class SurveyServlet extends HttpServlet {
       try {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException e) {
-        userEntity = new Entity(userKey);
-        userEntity.setProperty("firebaseID", userID);
-        datastore.put(userEntity);
+        userEntity = Utils.makeUserEntity(userID, true);
       }
 
       // save score of each survey metric as an entity property

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -182,6 +182,8 @@ public class UserServlet extends HttpServlet {
         LOGGER.info("event " + eventId + " has already been saved");
         return;
       }
+
+      // update attendee count
       Object attendees = eventEntity.getProperty("attendeeCount");
       int attendeeCount = 1;
       if (attendees != null) {
@@ -194,6 +196,10 @@ public class UserServlet extends HttpServlet {
       }
       eventEntity.setProperty("attendeeCount", attendeeCount);
       datastore.put(eventEntity);
+
+      // record interaction
+      int delta = Interactions.recordInteraction(userID, keyId, Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+        Interactions.updatePrefs(userEntity, tags, delta);
       saved.add(eventId);
       userEntity.setProperty("saved", saved);
     } catch (EntityNotFoundException e) {
@@ -214,6 +220,7 @@ public class UserServlet extends HttpServlet {
     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
     Key eventKey = KeyFactory.createKey("Event", eventId);
     try {
+      // update attendee count
       Entity eventEntity = datastore.get(eventKey);
       Object attendees = eventEntity.getProperty("attendeeCount");
       int attendeeCount = -1;
@@ -230,6 +237,11 @@ public class UserServlet extends HttpServlet {
       }
       eventEntity.setProperty("attendeeCount", attendeeCount);
       datastore.put(eventEntity);
+
+      // record interaction
+      int delta = Interactions.recordInteraction(userID, keyId, Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+        Interactions.updatePrefs(userEntity, tags, delta);
+
     } catch (EntityNotFoundException e) {
       LOGGER.info("event " + eventId + " does not exist");
     }

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -61,6 +61,7 @@ public class UserServlet extends HttpServlet {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException exception) {
         userEntity = Utils.makeUserEntity(userID, true);
+        LOGGER.info("No entity found for " + userID + ", creating one now.");
       }
       switch (request.getParameter("get")) {
         case "saved":
@@ -147,6 +148,7 @@ public class UserServlet extends HttpServlet {
       userEntity = datastore.get(userKey);
     } catch (EntityNotFoundException exception) {
       userEntity = Utils.makeUserEntity(userID, false);
+      LOGGER.info("No entity found for " + userID + ", creating one now.");
     }
     switch (request.getParameter("action")) {
       case "save":

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -60,10 +60,7 @@ public class UserServlet extends HttpServlet {
       try {
         userEntity = datastore.get(userKey);
       } catch (EntityNotFoundException exception) {
-        // datastore entry has not been created yet for this user, create it now
-        userEntity = new Entity(userKey);
-        userEntity.setProperty("firebaseID", userID);
-        datastore.put(userEntity);
+        userEntity = Utils.makeUserEntity(userID, true);
       }
       switch (request.getParameter("get")) {
         case "saved":
@@ -149,10 +146,7 @@ public class UserServlet extends HttpServlet {
     try {
       userEntity = datastore.get(userKey);
     } catch (EntityNotFoundException exception) {
-      // datastore entry has not been created yet for this user, create it now
-      userEntity = new Entity(userKey);
-      userEntity.setProperty("firebaseID", userID);
-      datastore.put(userEntity);
+      userEntity = Utils.makeUserEntity(userID, false);
     }
     switch (request.getParameter("action")) {
       case "save":

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -201,7 +201,7 @@ public class UserServlet extends HttpServlet {
       // record interaction
       int delta =
           Interactions.recordInteraction(
-              userEntity.getKey().getName(), eventId, Interactions.SAVE_SCORE);
+              userEntity.getKey().getName(), eventId, Interactions.SAVE_SCORE, false);
       List<String> tags = (List<String>) eventEntity.getProperty("tags");
       if (tags != null) {
         Interactions.updatePrefs(userEntity, tags, delta);
@@ -250,7 +250,8 @@ public class UserServlet extends HttpServlet {
           Interactions.recordInteraction(
               userEntity.getKey().getName(),
               eventId,
-              Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+              Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA,
+              true);
       List<String> tags = (List<String>) eventEntity.getProperty("tags");
       if (tags != null) {
         Interactions.updatePrefs(userEntity, tags, delta);

--- a/src/main/java/com/google/sps/servlets/UserServlet.java
+++ b/src/main/java/com/google/sps/servlets/UserServlet.java
@@ -25,6 +25,7 @@ import com.google.appengine.api.datastore.Query;
 import com.google.appengine.api.datastore.Query.SortDirection;
 import com.google.gson.Gson;
 import com.google.sps.Firebase;
+import com.google.sps.Interactions;
 import com.google.sps.Utils;
 import java.io.IOException;
 import java.util.ArrayList;
@@ -198,8 +199,14 @@ public class UserServlet extends HttpServlet {
       datastore.put(eventEntity);
 
       // record interaction
-      int delta = Interactions.recordInteraction(userID, keyId, Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+      int delta =
+          Interactions.recordInteraction(
+              userEntity.getKey().getName(), eventId, Interactions.SAVE_SCORE);
+      List<String> tags = (List<String>) eventEntity.getProperty("tags");
+      if (tags != null) {
         Interactions.updatePrefs(userEntity, tags, delta);
+      }
+
       saved.add(eventId);
       userEntity.setProperty("saved", saved);
     } catch (EntityNotFoundException e) {
@@ -239,9 +246,15 @@ public class UserServlet extends HttpServlet {
       datastore.put(eventEntity);
 
       // record interaction
-      int delta = Interactions.recordInteraction(userID, keyId, Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+      int delta =
+          Interactions.recordInteraction(
+              userEntity.getKey().getName(),
+              eventId,
+              Interactions.SAVE_SCORE + Interactions.UNSAVE_DELTA);
+      List<String> tags = (List<String>) eventEntity.getProperty("tags");
+      if (tags != null) {
         Interactions.updatePrefs(userEntity, tags, delta);
-
+      }
     } catch (EntityNotFoundException e) {
       LOGGER.info("event " + eventId + " does not exist");
     }

--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -95,6 +95,7 @@ public final class EventServletTest {
     // Assert only one Entity was posted to Datastore.
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     assertEquals(1, ds.prepare(new Query("Event")).countEntities(withLimit(10)));
+    assertEquals(1, ds.prepare(new Query("Interaction")).countEntities(withLimit(10)));
   }
 
   @Test
@@ -124,6 +125,14 @@ public final class EventServletTest {
     // Assert all three Entities were posted to Datastore.
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     assertEquals(3, ds.prepare(new Query("Event")).countEntities(withLimit(10)));
+    Iterable<Entity> interactions = ds.prepare(new Query("Interaction")).asIterable();
+    int size = 0;
+    for (Entity e : interactions) {
+      size++;
+      assertEquals(Interactions.CREATE_SCORE, Integer.parseInt(e.getProperty("rating").toString()));
+      assertEquals("test@example.com", e.getProperty("user").toString());
+    }
+    assertEquals(3, size);
   }
 
   @Test

--- a/src/test/java/com/google/sps/InteractionsTest.java
+++ b/src/test/java/com/google/sps/InteractionsTest.java
@@ -153,6 +153,14 @@ public final class InteractionsTest {
     // blm protest (test@example), book drive (another@example), lake clean up(test@example)
     UserServletTest.postEventsSetup();
     List<Entity> allEntities = UserServletTest.callGet("", "");
+    long id0 = allEntities.get(0).getKey().getId(); // blm protest (test@example)
+    long id1 = allEntities.get(1).getKey().getId(); // book drive (another @example)
+    long id2 = allEntities.get(2).getKey().getId(); // lake clean up (test@example)
+
+    UserServletTest.callPost(id1, "save", "test@example.com");
+    UserServletTest.callPost(id1, "save", "test@example.com");
+    UserServletTest.callPost(id1, "save", "another@example.com");
+    UserServletTest.callPost(id1, "save", "person@example.com");
 
     //test@example.com -> created blm protest, created lake clean up, saved book drive, viewed all 3
     //another @example.com -> created book drive, saved book drive, viewed lake clean up

--- a/src/test/java/com/google/sps/InteractionsTest.java
+++ b/src/test/java/com/google/sps/InteractionsTest.java
@@ -34,10 +34,8 @@ import com.google.appengine.api.datastore.Query.FilterOperator;
 import com.google.appengine.api.datastore.Query.FilterPredicate;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
-import com.google.sps.servlets.EventServlet;
 import com.google.sps.servlets.LoadEventServlet;
 import com.google.sps.servlets.SurveyServlet;
-import com.google.sps.servlets.UserServlet;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
@@ -154,31 +152,25 @@ public final class InteractionsTest {
   @Test
   public void recordMiscInteractions() throws IOException, ServletException {
     PowerMockito.mockStatic(Firebase.class);
-
-    EventServlet eventServlet = new EventServlet();
-    LoadEventServlet loadServlet = new LoadEventServlet();
-    UserServlet userServlet = new UserServlet();
-    DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
+    final LoadEventServlet loadServlet = new LoadEventServlet();
+    final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
     // blm protest (test@example), book drive (another@example), lake clean up(test@example)
     UserServletTest.postEventsSetup();
     List<Entity> allEntities = UserServletTest.callGet("", "");
-    long id0 = allEntities.get(0).getKey().getId(); // blm protest (test@example)
-    long id1 = allEntities.get(1).getKey().getId(); // book drive (another @example)
-    long id2 = allEntities.get(2).getKey().getId(); // lake clean up (test@example)
-    String key0 = allEntities.get(0).getProperty("eventKey").toString();
-    String key1 = allEntities.get(1).getProperty("eventKey").toString();
-    String key2 = allEntities.get(2).getProperty("eventKey").toString();
+    final long id0 = allEntities.get(0).getKey().getId();
+    final long id1 = allEntities.get(1).getKey().getId();
+    final long id2 = allEntities.get(2).getKey().getId();
 
-    UserServletTest.callPost(id1, "save", "person@example.com");
+    final String key0 = allEntities.get(0).getProperty("eventKey").toString();
+    final String key1 = allEntities.get(1).getProperty("eventKey").toString();
+    final String key2 = allEntities.get(2).getProperty("eventKey").toString();
 
     HttpServletRequest request = mock(HttpServletRequest.class);
-    HttpServletResponse response = mock(HttpServletResponse.class);
     RequestDispatcher dispatcher = mock(RequestDispatcher.class);
     when(request.getRequestDispatcher("/WEB-INF/jsp/display-event.jsp")).thenReturn(dispatcher);
 
-    // actions by test@example: created blm protest, created lake clean up, saved book drive, viewed
-    // all
+    // test@example: created blm protest, created lake clean up, saved book drive, viewed all
     String dummyToken = "test@example.com";
 
     UserServletTest.callPost(id1, "save", dummyToken);
@@ -188,6 +180,7 @@ public final class InteractionsTest {
     PowerMockito.when(Firebase.isUserLoggedIn(anyString())).thenCallRealMethod();
     PowerMockito.when(Firebase.authenticateUser(anyString())).thenReturn(dummyToken);
 
+    HttpServletResponse response = mock(HttpServletResponse.class);
     when(request.getParameter("Event")).thenReturn(key0);
     loadServlet.doGet(request, response);
 
@@ -202,7 +195,7 @@ public final class InteractionsTest {
     assertExpectedInteraction(dummyToken, id1, Interactions.SAVE_SCORE);
     assertExpectedInteraction(dummyToken, id2, Interactions.CREATE_SCORE);
 
-    // actions by another@example: created book drive, saved book drive, viewed lake clean up
+    // another@example: created book drive, saved book drive, viewed lake clean up
     dummyToken = "another@example.com";
 
     UserServletTest.callPost(id1, "save", "another@example.com");

--- a/src/test/java/com/google/sps/SurveyServletTest.java
+++ b/src/test/java/com/google/sps/SurveyServletTest.java
@@ -32,11 +32,13 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 /** Tests for the SurveyServlet.java class */
+@PowerMockIgnore("okhttp3.*")
 @RunWith(PowerMockRunner.class)
 @SuppressStaticInitializationFor({"com.google.sps.Firebase"})
 @PrepareForTest({Firebase.class})

--- a/src/test/java/com/google/sps/TestingUtil.java
+++ b/src/test/java/com/google/sps/TestingUtil.java
@@ -76,7 +76,7 @@ public final class TestingUtil {
   }
 
   /**
-   * Use the current url to login/logout.
+   * Use the current url to login/logout (DEPRECATED)
    *
    * @param email If logging in, will log into this user's account.
    */

--- a/src/test/java/com/google/sps/UserServletTest.java
+++ b/src/test/java/com/google/sps/UserServletTest.java
@@ -395,13 +395,13 @@ public final class UserServletTest {
   /** Performs the POST request to save or unsave an event with a given id. */
   public static void callPost(long id, String action, String dummyToken) throws IOException {
     HttpServletRequest request = mock(HttpServletRequest.class);
-    HttpServletResponse response = mock(HttpServletResponse.class);
     PowerMockito.mockStatic(Firebase.class);
     when(request.getParameter("event")).thenReturn(id + "");
     when(request.getParameter("action")).thenReturn(action);
     when(request.getParameter("userToken")).thenReturn(dummyToken);
     PowerMockito.when(Firebase.isUserLoggedIn(anyString())).thenCallRealMethod();
     PowerMockito.when(Firebase.authenticateUser(anyString())).thenReturn(dummyToken);
+    HttpServletResponse response = mock(HttpServletResponse.class);
     testUserServlet.doPost(request, response);
   }
 

--- a/src/test/java/com/google/sps/UserServletTest.java
+++ b/src/test/java/com/google/sps/UserServletTest.java
@@ -375,13 +375,13 @@ public final class UserServletTest {
   /** Performs the GET request to return a list of events. */
   public static List<Entity> callGet(String get, String dummyToken) throws IOException {
     HttpServletRequest request = mock(HttpServletRequest.class);
-    HttpServletResponse response = mock(HttpServletResponse.class);
     PowerMockito.mockStatic(Firebase.class);
     when(request.getParameter("get")).thenReturn(get);
     PowerMockito.when(request.getParameter("userToken")).thenReturn(dummyToken);
     PowerMockito.when(Firebase.isUserLoggedIn(anyString())).thenCallRealMethod();
     PowerMockito.when(Firebase.authenticateUser(anyString())).thenReturn(dummyToken);
 
+    HttpServletResponse response = mock(HttpServletResponse.class);
     StringWriter out = new StringWriter();
     PrintWriter writer = new PrintWriter(out);
     when(response.getWriter()).thenReturn(writer);

--- a/src/test/java/com/google/sps/UserServletTest.java
+++ b/src/test/java/com/google/sps/UserServletTest.java
@@ -192,9 +192,9 @@ public final class UserServletTest {
     postEventsSetup();
     List<Entity> allEntities = callGet("", "");
 
-    long id0 = allEntities.get(0).getKey().getId();
-    long id1 = allEntities.get(1).getKey().getId();
-    long id2 = allEntities.get(2).getKey().getId();
+    final long id0 = allEntities.get(0).getKey().getId();
+    final long id1 = allEntities.get(1).getKey().getId();
+    final long id2 = allEntities.get(2).getKey().getId();
     List<Entity> goalList = new ArrayList<>();
     goalList.add(allEntities.get(0));
     goalList.add(allEntities.get(2));

--- a/src/test/java/com/google/sps/UserServletTest.java
+++ b/src/test/java/com/google/sps/UserServletTest.java
@@ -108,27 +108,6 @@ public final class UserServletTest {
     }
   }
 
-  //   /** Makes sure interactions have been recorded correctly in datastore. */
-  //   private void assertExpectedInteraction(String userId, long eventId, int value) {
-  //     DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
-  //     Query q =
-  //         new Query("Interaction")
-  //             .setFilter(
-  //                 CompositeFilterOperator.and(
-  //                     new FilterPredicate("user", FilterOperator.EQUAL, userId),
-  //                     new FilterPredicate("event", FilterOperator.EQUAL, eventId)));
-  //     PreparedQuery pq = datastore.prepare(q);
-  //     try {
-  //       Entity interactionEntity = pq.asSingleEntity();
-  //       int score = Integer.parseInt(interactionEntity.getProperty("rating").toString());
-  //       assertEquals(value, score);
-  //     } catch (TooManyResultsException e) {
-  //       fail();
-  //     } catch (NullPointerException e) {
-  //       fail();
-  //     }
-  //   }
-
   /** Sets up the datastore helper and authentication utility for each test. */
   @Before
   public void setUp() throws IOException {


### PR DESCRIPTION
Added a system of saving users' interactions with events as an "Interaction" entity in datastore, with a userId, eventId, rating (depending on the type of interaction) and timestamp. Only 1 interaction is saved for each userId-event-Id pair (saving the highest rating). Additionally, user preferences are updated according to the same rating system and the event's tags.

I also did a lot of refactoring (which is also why lines-changed is so high), where I moved some methods around and also put the user entity creation into its own Utils method.