### PR TITLE
Fix failing tests

### DIFF
--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -33,7 +33,6 @@ import com.google.sps.servlets.EventServlet;
 import com.google.sps.servlets.KeywordSearchServlet;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -181,7 +180,7 @@ public final class EventServletTest {
     Map<String, Integer> keywords =
         KeywordSearchServlet.getKeywords("Lake Clean Up", "We're cleaning up the lake");
     goalEntity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
-    goalEntity.setProperty("keywordsValues", new ArrayList<Integer>(Arrays.asList(3, 3, 2)));
+    goalEntity.setProperty("keywordsValues", KeywordSearchServlet.getKeywordMapValues(keywords));
 
     // Retrieve the Entity posted to Datastore.
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();

--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -17,6 +17,7 @@ package com.google.sps;
 import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
 import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.*;
 
@@ -189,7 +190,6 @@ public final class EventServletTest {
     // Assert the Entity posted to Datastore has the same properties as the
     // the goalEntity.
     assertEntitiesEqual(goalEntity, postedEntity);
-    // assertEquals(goalEntity.getProperties(), postedEntity.getProperties());
   }
 
   @Test
@@ -255,7 +255,10 @@ public final class EventServletTest {
     Set<String> resultProperties = resultEntity.getProperties().keySet();
     assertEquals(goalProperties.size(), resultProperties.size());
     for (String s : goalProperties) {
-      if (!(s.equals("keywordsValues"))) {
+      if (s.equals("keywordsValues")) {
+        assertTrue(
+            ((goal.getProperty(s)).toString()).equals((resultEntity.getProperty(s)).toString()));
+      } else {
         assertEquals(goal.getProperty(s), resultEntity.getProperty(s));
       }
     }

--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -15,7 +15,6 @@
 package com.google.sps;
 
 import static com.google.appengine.api.datastore.FetchOptions.Builder.withLimit;
-import static org.hamcrest.CoreMatchers.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -160,7 +159,7 @@ public final class EventServletTest {
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     Entity postedEntity = ds.prepare(new Query("Event")).asSingleEntity();
 
-    Entity goalEntity = createEntity();
+    Entity goalEntity = createEntity(creatorEmail, tagsStr);
 
     // Assert the Entity posted to Datastore has the same properties as the
     // the goalEntity.
@@ -225,7 +224,7 @@ public final class EventServletTest {
     }
   }
 
-  private Entity createEntity() {
+  private Entity createEntity(String email, String tagsStr) {
     // Create what the event Entity should look like, but do not post to
     // it to Datastore.
     Entity entity = new Entity("Event");
@@ -236,7 +235,7 @@ public final class EventServletTest {
     entity.setProperty("startTime", "2:00 PM");
     entity.setProperty("endTime", "3:00 PM");
     entity.setProperty("coverPhoto", "/img-2030121");
-    entity.setProperty("creator", "test@example.com");
+    entity.setProperty("creator", email);
     entity.setProperty("attendeeCount", 0L);
     entity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgBDA");
     entity.setProperty("unformattedStart", "14:00");
@@ -244,8 +243,6 @@ public final class EventServletTest {
     entity.setProperty("unformattedDate", "2020-05-17");
 
     // Convert tags and set tag property.
-    String[] tagsArr = {"environment"};
-    String tagsStr = Utils.convertToJson(tagsArr);
     Gson gson = new Gson();
     List<String> tags = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
     entity.setIndexedProperty("tags", tags);

--- a/src/test/java/com/google/sps/EventServletTest.java
+++ b/src/test/java/com/google/sps/EventServletTest.java
@@ -156,35 +156,11 @@ public final class EventServletTest {
     // Post event to Datastore.
     testEventServlet.doPost(request, response);
 
-    // Create what the event Entity should look like, but do not post to
-    // it to Datastore.
-    Entity goalEntity = new Entity("Event");
-    goalEntity.setProperty("eventName", "Lake Clean Up");
-    goalEntity.setProperty("eventDescription", "We're cleaning up the lake");
-    goalEntity.setProperty("address", "678 Lakeview Way, Lakeside, Michigan");
-    goalEntity.setProperty("date", "Sunday, May 17, 2020");
-    goalEntity.setProperty("startTime", "2:00 PM");
-    goalEntity.setProperty("endTime", "3:00 PM");
-    goalEntity.setProperty("coverPhoto", "/img-2030121");
-    goalEntity.setProperty("creator", creatorEmail);
-    goalEntity.setProperty("attendeeCount", 0L);
-    goalEntity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgBDA");
-    goalEntity.setProperty("unformattedStart", "14:00");
-    goalEntity.setProperty("unformattedEnd", "15:00");
-    goalEntity.setProperty("unformattedDate", "2020-05-17");
-
-    Gson gson = new Gson();
-    List<String> tagsList = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
-    goalEntity.setIndexedProperty("tags", tagsList);
-
-    Map<String, Integer> keywords =
-        KeywordSearchServlet.getKeywords("Lake Clean Up", "We're cleaning up the lake");
-    goalEntity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
-    goalEntity.setProperty("keywordsValues", KeywordSearchServlet.getKeywordMapValues(keywords));
-
     // Retrieve the Entity posted to Datastore.
     DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     Entity postedEntity = ds.prepare(new Query("Event")).asSingleEntity();
+
+    Entity goalEntity = createEntity();
 
     // Assert the Entity posted to Datastore has the same properties as the
     // the goalEntity.
@@ -247,6 +223,40 @@ public final class EventServletTest {
       DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
       assertEquals(0, ds.prepare(new Query("Event")).countEntities());
     }
+  }
+
+  private Entity createEntity() {
+    // Create what the event Entity should look like, but do not post to
+    // it to Datastore.
+    Entity entity = new Entity("Event");
+    entity.setProperty("eventName", "Lake Clean Up");
+    entity.setProperty("eventDescription", "We're cleaning up the lake");
+    entity.setProperty("address", "678 Lakeview Way, Lakeside, Michigan");
+    entity.setProperty("date", "Sunday, May 17, 2020");
+    entity.setProperty("startTime", "2:00 PM");
+    entity.setProperty("endTime", "3:00 PM");
+    entity.setProperty("coverPhoto", "/img-2030121");
+    entity.setProperty("creator", "test@example.com");
+    entity.setProperty("attendeeCount", 0L);
+    entity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgBDA");
+    entity.setProperty("unformattedStart", "14:00");
+    entity.setProperty("unformattedEnd", "15:00");
+    entity.setProperty("unformattedDate", "2020-05-17");
+
+    // Convert tags and set tag property.
+    String[] tagsArr = {"environment"};
+    String tagsStr = Utils.convertToJson(tagsArr);
+    Gson gson = new Gson();
+    List<String> tags = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
+    entity.setIndexedProperty("tags", tags);
+
+    // Retrieve keywords and set keyword properties.
+    Map<String, Integer> keywords =
+        KeywordSearchServlet.getKeywords("Lake Clean Up", "We're cleaning up the lake");
+    entity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
+    entity.setProperty("keywordsValues", KeywordSearchServlet.getKeywordMapValues(keywords));
+
+    return entity;
   }
 
   private void assertEntitiesEqual(Entity goal, Entity resultEntity) {

--- a/src/test/java/com/google/sps/UserServletTest.java
+++ b/src/test/java/com/google/sps/UserServletTest.java
@@ -33,6 +33,7 @@ import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.google.sps.servlets.EventServlet;
+import com.google.sps.servlets.KeywordSearchServlet;
 import com.google.sps.servlets.UserServlet;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -41,6 +42,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -71,7 +73,7 @@ public final class UserServletTest {
     assertEquals(goalProperties.size(), resultProperties.size());
     for (String s : goalProperties) {
       // ignore attendeeCount, which is checked elsewhere
-      if (!s.equals("attendeeCount")) {
+      if (!(s.equals("attendeeCount"))) {
         assertEquals(goal.getProperty(s), resultEntity.getProperty(s));
       }
     }
@@ -561,14 +563,23 @@ public final class UserServletTest {
     entity.setProperty("startTime", "2:00 PM");
     entity.setProperty("endTime", "");
     entity.setProperty("coverPhoto", "");
-    String[] tags = {"environment"};
-    entity.setIndexedProperty("tags", Arrays.asList(tags));
     entity.setProperty("creator", "test@example.com");
     entity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgBDA");
     entity.setProperty("attendeeCount", 1L);
     entity.setProperty("unformattedStart", "14:00");
     entity.setProperty("unformattedEnd", "");
     entity.setProperty("unformattedDate", "2020-05-17");
+
+    String[] tags = {"environment"};
+    String tagsStr = Utils.convertToJson(tags);
+    Gson gson = new Gson();
+    List<String> tagsList = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
+    entity.setIndexedProperty("tags", tagsList);
+
+    Map<String, Integer> keywords =
+        KeywordSearchServlet.getKeywords("Lake Clean Up", "We're cleaning up the lake");
+    entity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
+    entity.setProperty("keywordsValues", new ArrayList<Double>(Arrays.asList(3.0, 3.0, 2.0)));
 
     return entity;
   }
@@ -583,14 +594,23 @@ public final class UserServletTest {
     entity.setProperty("startTime", "1:00 PM");
     entity.setProperty("endTime", "");
     entity.setProperty("coverPhoto", "");
-    String[] tags = {"blm"};
-    entity.setIndexedProperty("tags", Arrays.asList(tags));
     entity.setProperty("creator", "test@example.com");
     entity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgDDA");
     entity.setProperty("attendeeCount", 1L);
     entity.setProperty("unformattedStart", "13:00");
     entity.setProperty("unformattedEnd", "");
     entity.setProperty("unformattedDate", "2020-05-17");
+
+    String[] tags = {"blm"};
+    String tagsStr = Utils.convertToJson(tags);
+    Gson gson = new Gson();
+    List<String> tagsList = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
+    entity.setIndexedProperty("tags", tagsList);
+
+    Map<String, Integer> keywords =
+        KeywordSearchServlet.getKeywords("BLM Protest", "Fight for racial justice!");
+    entity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
+    entity.setProperty("keywordsValues", new ArrayList<Double>(Arrays.asList(2.0, 2.0)));
 
     return entity;
   }
@@ -605,14 +625,23 @@ public final class UserServletTest {
     entity.setProperty("startTime", "10:00 AM");
     entity.setProperty("endTime", "");
     entity.setProperty("coverPhoto", "");
-    String[] tags = {"education"};
-    entity.setIndexedProperty("tags", Arrays.asList(tags));
     entity.setProperty("creator", "another@example.com");
     entity.setProperty("eventKey", "agR0ZXN0cgsLEgVFdmVudBgFDA");
     entity.setProperty("attendeeCount", 1L);
     entity.setProperty("unformattedStart", "10:00");
     entity.setProperty("unformattedEnd", "");
     entity.setProperty("unformattedDate", "2020-05-17");
+
+    String[] tags = {"education"};
+    String tagsStr = Utils.convertToJson(tags);
+    Gson gson = new Gson();
+    List<String> tagsList = gson.fromJson(tagsStr, new TypeToken<ArrayList<String>>() {}.getType());
+    entity.setIndexedProperty("tags", tagsList);
+
+    Map<String, Integer> keywords =
+        KeywordSearchServlet.getKeywords("Book Drive", "Let's donate books for kids");
+    entity.setProperty("keywords", KeywordSearchServlet.getKeywordMapKeys(keywords));
+    entity.setProperty("keywordsValues", new ArrayList<Double>(Arrays.asList(2.0, 2.0)));
 
     return entity;
   }


### PR DESCRIPTION
Added the missing entity keyword-related properties to the eventSevlet and userServlet tests.

I hardcoded the keywordsValues as floats because the tests weren't passing as integers. I also converted the keywordValues array to a string so I could call 'equals' on the two stings in the eventServlet test.