### PR TITLE
Location radius for recommendations

### DIFF
--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -89,6 +89,9 @@ public class Utils {
    * @return the latitude and longitude of the location
    */
   public static LatLng getLatLng(String location) {
+    if (location == null || location.length() == 0) {
+      return null;
+    }
     GeocodingResult[] results = null;
     try {
       GeocodingApiRequest request = GeocodingApi.newRequest(context);
@@ -117,9 +120,6 @@ public class Utils {
 
   /** Returns a location as a GeoPt. */
   public static GeoPt getGeopt(String location) {
-    if (location == null || location.length() == 0) {
-      return null;
-    }
     return getGeopt(getLatLng(location));
   }
 
@@ -132,6 +132,9 @@ public class Utils {
    * @return the distance in km between the two locations
    */
   public static int getDistance(LatLng from, LatLng to) {
+    if (from == null || to == null) {
+      return -1;
+    }
     DistanceMatrix result = null;
     try {
       DistanceMatrixApiRequest request = DistanceMatrixApi.newRequest(context);
@@ -162,14 +165,8 @@ public class Utils {
    * @return the distance in km between the two locations.
    */
   public static int getDistance(String from, String to) {
-    if (from.length() == 0 || to.length() == 0) {
-      return -1;
-    }
     LatLng start = getLatLng(from);
     LatLng end = getLatLng(to);
-    if (start == null || end == null) {
-      return -1;
-    }
     return getDistance(start, end);
   }
 

--- a/src/main/java/com/google/sps/Utils.java
+++ b/src/main/java/com/google/sps/Utils.java
@@ -101,7 +101,7 @@ public class Utils {
     } catch (IOException e) {
       LOGGER.warning(e.getMessage());
     }
-    if (results == null) {
+    if (results == null || results.length == 0) {
       return null;
     }
     return new LatLng(results[0].geometry.location.lat, results[0].geometry.location.lng);
@@ -117,7 +117,7 @@ public class Utils {
 
   /** Returns a location as a GeoPt. */
   public static GeoPt getGeopt(String location) {
-    if (location == null) {
+    if (location == null || location.length() == 0) {
       return null;
     }
     return getGeopt(getLatLng(location));

--- a/src/main/java/com/google/sps/servlets/RecommendServlet.java
+++ b/src/main/java/com/google/sps/servlets/RecommendServlet.java
@@ -18,9 +18,12 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.Query;
+import com.google.appengine.api.datastore.Query.GeoRegion.Circle;
+import com.google.appengine.api.datastore.Query.StContainsFilter;
 import com.google.gson.Gson;
 import com.google.sps.Firebase;
 import com.google.sps.Interactions;
@@ -43,6 +46,7 @@ public class RecommendServlet extends HttpServlet {
 
   private static final Logger LOGGER = Logger.getLogger(RecommendServlet.class.getName());
   private static final int EVENTS_LIMIT = 10;
+  private static final double RADIUS = 300_000;
 
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
@@ -121,6 +125,9 @@ public class RecommendServlet extends HttpServlet {
     String userLocation = null;
     if (userEntity.hasProperty("location")) {
       userLocation = userEntity.getProperty("location").toString();
+      GeoPt latlng = Utils.getGeopt(userLocation);
+      datastore.prepare(
+          new Query("Event").setFilter(new StContainsFilter("latlng", new Circle(latlng, RADIUS))));
     }
     List<Entity> events = new ArrayList<>();
     Map<Double, Entity> bestEvents = new TreeMap<>(Recommend.SCORE_DESCENDING);

--- a/src/test/java/com/google/sps/RecommendTest.java
+++ b/src/test/java/com/google/sps/RecommendTest.java
@@ -345,7 +345,6 @@ public final class RecommendTest {
     String events = "src/test/data/events-2.csv";
     addInfoToDatastore(events, null, null);
 
-    DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     // create userEntity that has high affinity with events in events-2.csv
     Entity userEntity = new Entity("User", "test@example.com");
     userEntity.setProperty("environment", 10);
@@ -353,6 +352,8 @@ public final class RecommendTest {
     userEntity.setProperty("activism", 10);
     userEntity.setProperty("fundraiser", 10);
     userEntity.setProperty("education", 10);
+
+    DatastoreService ds = DatastoreServiceFactory.getDatastoreService();
     ds.put(userEntity);
 
     for (int i = 6; i <= 306; i++) {

--- a/src/test/java/com/google/sps/RecommendTest.java
+++ b/src/test/java/com/google/sps/RecommendTest.java
@@ -25,6 +25,7 @@ import com.google.appengine.api.datastore.DatastoreService;
 import com.google.appengine.api.datastore.DatastoreServiceFactory;
 import com.google.appengine.api.datastore.Entity;
 import com.google.appengine.api.datastore.EntityNotFoundException;
+import com.google.appengine.api.datastore.GeoPt;
 import com.google.appengine.api.datastore.Key;
 import com.google.appengine.api.datastore.KeyFactory;
 import com.google.appengine.api.datastore.PreparedQuery;
@@ -70,6 +71,18 @@ public final class RecommendTest {
   @Before
   public void setUp() throws IOException {
     helper.setUp();
+
+    PowerMockito.mockStatic(Utils.class);
+    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
+    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
+    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
+    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
+    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
+    PowerMockito.when(Utils.getGeopt("90045")).thenReturn(new GeoPt(33.959670f, -118.424991f));
+    PowerMockito.when(Utils.getGeopt("90301")).thenReturn(new GeoPt(33.954740f, -118.360363f));
+    PowerMockito.when(Utils.getGeopt("90305")).thenReturn(new GeoPt(33.955859f, -118.321683f));
+    PowerMockito.when(Utils.getGeopt("90047")).thenReturn(new GeoPt(33.956506f, -118.305864f));
+    PowerMockito.when(Utils.getGeopt("90003")).thenReturn(new GeoPt(33.960939f, -118.272003f));
   }
 
   @After
@@ -79,9 +92,6 @@ public final class RecommendTest {
 
   @Test
   public void checkOutput() throws IOException {
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90001", "90001")).thenReturn(0);
-
     // a test to make sure everything is in an expected format and runs without hiccups
     String users = "src/test/data/users-1.csv";
     String ratings = "src/test/data/ratings-1.csv";
@@ -109,19 +119,6 @@ public final class RecommendTest {
 
   @Test
   public void rankFromDistance() throws IOException, Exception {
-    // set up distance mocking
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
-    PowerMockito.when(Utils.getDistance("90003", "90003")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90003", "90047")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90003", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90003", "90301")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90003", "90045")).thenReturn(40);
-
     // check that recommendation ranks distances correctly
     String users = "src/test/data/users-2.csv";
     String ratings = "src/test/data/ratings-none.csv";
@@ -159,9 +156,6 @@ public final class RecommendTest {
 
   @Test
   public void rankWithoutInteractions() throws IOException {
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-
     // test that ranks are calculated correctly when interactions and locations are held constant
     String users = "src/test/data/users-3.csv";
     String ratings = "src/test/data/ratings-none.csv";
@@ -191,14 +185,6 @@ public final class RecommendTest {
 
   @Test
   public void noRecommendationsServlet() throws IOException {
-    // similar to rankFromDistance(), but performed through the servlet instead
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
-
     String users = "src/test/data/users-2.csv";
     String ratings = "src/test/data/ratings-none.csv";
     String events = "src/test/data/events-2.csv";
@@ -235,19 +221,6 @@ public final class RecommendTest {
 
   @Test
   public void returnRecommendations() throws IOException {
-    // similar to rankFromDistance(), but performed through the servlet instead
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
-    PowerMockito.when(Utils.getDistance("90003", "90003")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90003", "90047")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90003", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90003", "90301")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90003", "90045")).thenReturn(40);
-
     // check that recommendation ranks distances correctly
     String users = "src/test/data/users-2.csv";
     String ratings = "src/test/data/ratings-none.csv";
@@ -265,13 +238,6 @@ public final class RecommendTest {
 
   @Test
   public void problematicEntity() throws IOException {
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
-
     String users = "src/test/data/users-2.csv";
     String ratings = "src/test/data/ratings-none.csv";
     String events = "src/test/data/events-2.csv";
@@ -319,13 +285,6 @@ public final class RecommendTest {
 
   @Test
   public void completedSurvey() throws IOException {
-    PowerMockito.mockStatic(Utils.class);
-    PowerMockito.when(Utils.getDistance("90045", "90045")).thenReturn(0);
-    PowerMockito.when(Utils.getDistance("90045", "90301")).thenReturn(10);
-    PowerMockito.when(Utils.getDistance("90045", "90305")).thenReturn(20);
-    PowerMockito.when(Utils.getDistance("90045", "90047")).thenReturn(30);
-    PowerMockito.when(Utils.getDistance("90045", "90003")).thenReturn(40);
-
     String users = "src/test/data/users-2.csv";
     String ratings = "src/test/data/ratings-none.csv";
     String events = "src/test/data/events-2.csv";

--- a/src/test/java/com/google/sps/SearchServletTest.java
+++ b/src/test/java/com/google/sps/SearchServletTest.java
@@ -161,6 +161,13 @@ public final class SearchServletTest {
 
   @Test
   public void emptyStrings() throws Exception {
+    String nullString = null;
+
+    assertEquals(null, Utils.getLatLng(nullString));
+    assertEquals(null, Utils.getLatLng(""));
+    assertEquals(null, Utils.getGeopt(nullString));
+    assertEquals(null, Utils.getGeopt(""));
+
     assertEquals(-1, Utils.getDistance("", null));
     assertEquals(-1, Utils.getDistance("", ""));
   }

--- a/src/test/java/com/google/sps/SearchServletTest.java
+++ b/src/test/java/com/google/sps/SearchServletTest.java
@@ -139,7 +139,7 @@ public final class SearchServletTest {
     assertEquals(-31.95220010, geopt.getLatitude(), 0.0001);
     assertEquals(115.85884740, geopt.getLongitude(), 0.0001);
   }
-  
+
   @Test
   public void getDistanceStrings() throws Exception {
     LatLng loc = new LatLng(-31.95220010, 115.85884740);


### PR DESCRIPTION
Increase efficiency of "fast" recommendation algorithm (the one that does not go through Spark) -- instead of querying all events from datastore to find a match, a cutoff is applied. If the user has specified a location, only events that are in a 300km radius are returned. Otherwise, the events with the highest number of attendees are returned